### PR TITLE
Use callback for setting refs instead of strings

### DIFF
--- a/src/EventItem.js
+++ b/src/EventItem.js
@@ -14,6 +14,8 @@ class EventItem extends Component {
             top: top,
             width: width,
         };
+        this.startResizer = null;
+        this.endResizer = null;
     }
 
     static propTypes = {
@@ -275,10 +277,10 @@ class EventItem extends Component {
         let eventTitle = isInPopover ? `${start.format('HH:mm')} ${titleText}` : titleText;
         let startResizeDiv = <div />;
         if (this.startResizable(this.props))
-            startResizeDiv = <div className="event-resizer event-start-resizer" ref='startResizer'></div>;
+            startResizeDiv = <div className="event-resizer event-start-resizer" ref={(ref) => this.startResizer = ref}></div>;
         let endResizeDiv = <div />;
         if (this.endResizable(this.props))
-            endResizeDiv = <div className="event-resizer event-end-resizer" ref='endResizer'></div>;
+            endResizeDiv = <div className="event-resizer event-end-resizer" ref={(ref) => this.endResizer = ref}></div>;
 
         let eventItemTemplate = (
             <div className={roundCls + ' event-item'} key={eventItem.id}


### PR DESCRIPTION
Using strings for setting refs is considered to be a legacy API:
https://reactjs.org/docs/refs-and-the-dom.html#legacy-api-string-refs

-------------

Hi,

thanks for the work on this library! While using it I came across an error which was caused by these strings refs, basically stating that string refs are legacy and that we should not use them. I'm not sure why they manifested with our setup and not for instance in the demo project you have hosted for us. It might have something to do with the build process we have: we are using a `create-react-app` based tooling for building and development.

In essence we'd always get an error when we didn't set `startResizable` and `endResizable` as `false` in our config for `SchedulerData`.

But string refs are legacy so I thought that it might be prudent just to refactor them to use one of the accepted patterns. Hopefully this example PR will help you in some way.