### PR TITLE
Replace text-decoration-skip: ink to text-decoration-skip-ink: auto w…

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "lint"
   ],
   "dependencies": {
-    "antd": "^3.9.0",
+    "antd": "^3.16.5",
     "moment": "^2.18.1",
     "prop-types": "^15.6.1",
     "react": "^16.0.0",


### PR DESCRIPTION
…arning fix

Increase antd version so the 'Replace text-decoration-skip: ink to text-decoration-skip-ink: auto, because spec had been changed' warning is fixed. The fix came in at version 3.12.4 (https://github.com/ant-design/ant-design/releases/tag/3.12.4)