### PR TITLE
fixes edge case: dragging event

### DIFF
--- a/src/DnDContext.js
+++ b/src/DnDContext.js
@@ -65,6 +65,9 @@ export default class DnDContext {
                 }
                 const point = monitor.getClientOffset();                
                 let leftIndex = Math.floor((point.x - pos.x)/cellWidth);
+                if(!resourceEvents.headerItems[leftIndex]) {
+                    return;
+                }
                 let newStart = resourceEvents.headerItems[leftIndex].start;
                 let newEnd = resourceEvents.headerItems[leftIndex].end;
                 if(cellUnit !== CellUnits.Hour)


### PR DESCRIPTION
There is an edge case where if you are dragging an event to outside of the table and then bring it back, it gives an error:

Uncaught TypeError: Cannot read property 'start' of undefined
    at Object.hover (DnDContext.js:99)
    at TargetImpl.hover (createTargetFactory.js:46)
    at hoverAllTargets (hover.js:71)
    at DragDropManagerImpl.hover (hover.js:23)
    at Object.hover (DragDropManagerImpl.js:93)
    at HTML5Backend.handleTopDragEnter (HTML5Backend.js:234)

This happens frequently during week view