### PR TITLE
fixed a bug that double an hour on time change & allow hours to be displayed over two days

### DIFF
--- a/src/SchedulerData.js
+++ b/src/SchedulerData.js
@@ -604,7 +604,14 @@ export default class SchedulerData {
                 end = end.add(this.config.dayStopTo, 'hours');
                 header = start;
 
+                let prevHour = -1;
                 while (header >= start && header <= end) {
+                    // prevent doubled hours on time change
+                    if (header.hour() == prevHour) {
+                        header = header.add(1, 'hours');
+                        continue;
+                    }
+                    prevHour = header.hour();
                     let minuteSteps = this.getMinuteStepsInHour();
                     for(let i=0; i<minuteSteps; i++){
                         let hour = header.hour();
@@ -613,7 +620,7 @@ export default class SchedulerData {
                             let nonWorkingTime = this.behaviors.isNonWorkingTimeFunc(this, time);
                             headers.push({ time: time, nonWorkingTime: nonWorkingTime });
                         }
-    
+
                         header = header.add(this.config.minuteStep, 'minutes');
                     }
                 }

--- a/src/SchedulerData.js
+++ b/src/SchedulerData.js
@@ -600,8 +600,10 @@ export default class SchedulerData {
         }
         else {
             if (this.cellUnit === CellUnits.Hour) {
-                start = start.add(this.config.dayStartFrom, 'hours');
-                end = end.add(this.config.dayStopTo, 'hours');
+                if (start.hour() == 0)
+                    start = start.add(this.config.dayStartFrom, 'hours');
+                if (end.hour() == 0)
+                    end = end.add(this.config.dayStopTo, 'hours');
                 header = start;
 
                 let prevHour = -1;


### PR DESCRIPTION
On time change (for example today in France), on hour of the day is doubled, which causes visual bugs.

In addition, a small change on dayStartFrom/dayStopTo. Currently, it is not possible to have a calendar straddling two days (e. g. from 8pm to 8am) because dayStopTo is added to the end time, increasing the gap from 12 to 36 hours.